### PR TITLE
Don't show objectives for completed quests

### DIFF
--- a/Modules/Display.lua
+++ b/Modules/Display.lua
@@ -581,10 +581,12 @@ function Module:GetSectionQuests(week, section, chore, showCompleted, showObject
                         local shoppingText = '    * Bring ' .. bringMe[1] .. 'x ' .. bringName .. '|r'
                         table.insert(section.entries, shoppingText)
                     end
-                elseif bestState.status == 1 and bestState.objectives ~= nil and #bestState.objectives > 1 then
-                    self:AddObjectives(section.entries, bestState.objectives, showObjectives)
-                elseif bestWeek ~= nil and bestWeek.objectives ~= nil and #bestWeek.objectives > 1 then
-                    self:AddObjectives(section.entries, bestWeek.objectives, showObjectives)
+                elseif bestState.status == 1 then
+                    if bestState.objectives ~= nil and #bestState.objectives > 1 then
+                        self:AddObjectives(section.entries, bestState.objectives, showObjectives)
+                    elseif bestWeek ~= nil and bestWeek.objectives ~= nil and #bestWeek.objectives > 1 then
+                        self:AddObjectives(section.entries, bestWeek.objectives, showObjectives)
+                    end
                 end
             end
         end


### PR DESCRIPTION
Don't show objectives for completed quests. Fixes https://github.com/ThingEngineering/choretracker/issues/3.

Before:
![Superbloom-with-objectives](https://github.com/ThingEngineering/choretracker/assets/6314272/f0443bb8-7477-43f4-9ac0-dc89ef5b68dd)

After:
![Superbloom-no-objetives](https://github.com/ThingEngineering/choretracker/assets/6314272/84f95dfe-297b-40a0-a0b0-4c15fb63943a)

