### PR TITLE
Add Alliance quest ID for "A Time to Reflect"

### DIFF
--- a/Data/Chores/Events/Anniversary.lua
+++ b/Data/Chores/Events/Anniversary.lua
@@ -18,7 +18,8 @@ Addon.data.chores.choresAnniversary = {
                     dailyQuest = true,
                     requiredEventIds = anniversaryIds,
                     entries = {
-                        { quest = 43461 }, -- A Time to Reflect
+                        { quest = 43323 }, -- A Time to Reflect [A]
+                        { quest = 43461 }, -- A Time to Reflect [H]
                     },
                 },
                 {


### PR DESCRIPTION
Chore tracker is only checking the Horde version (43461) https://www.wowhead.com/quest=43461/a-time-to-reflect

Equivalent Alliance quest has a different ID (43323) https://www.wowhead.com/quest=43323/a-time-to-reflect and does not mark the Horde version as complete once done.