### PR TITLE
Add category to TOC

### DIFF
--- a/ChoreTracker.toc
+++ b/ChoreTracker.toc
@@ -7,6 +7,18 @@
 ## SavedVariables: ChoreTrackerDB
 ## AddonCompartmentFunc: ChoreTracker_OnAddonCompartmentClick
 
+## Category-enUS: Quests
+## Category-deDE: Quests
+## Category-esES: Misiones
+## Category-esMX: Misiones
+## Category-frFR: Quêtes
+## Category-itIT: Missioni
+## Category-koKR: 퀘스트
+## Category-ptBR: Missões
+## Category-ruRU: Задания
+## Category-zhCN: 任务
+## Category-zhTW: 任務
+
 Libs\LibStub\LibStub.lua
 Libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
 


### PR DESCRIPTION
Since Patch 11.1, it is possible to categorize an addon and group them. More info: https://warcraft.wiki.gg/wiki/Patch_11.1.0/API_changes

I think the “Quests” category is the most suitable. What do you think?