### PR TITLE
Use GetCurrentCalendarTime rather than calculating time

### DIFF
--- a/Modules/Display.lua
+++ b/Modules/Display.lua
@@ -26,7 +26,6 @@ local CC_GetDayEvent = C_Calendar.GetDayEvent
 local CC_GetNumDayEvents = C_Calendar.GetNumDayEvents
 local CCI_GetCurrencyInfo = C_CurrencyInfo.GetCurrencyInfo
 local CDAT_CompareCalendarTime = C_DateAndTime.CompareCalendarTime
-local CDAT_GetCalendarTimeFromEpoch = C_DateAndTime.GetCalendarTimeFromEpoch
 local CDAT_GetCurrentCalendarTime = C_DateAndTime.GetCurrentCalendarTime
 local CDAT_GetSecondsUntilWeeklyReset = C_DateAndTime.GetSecondsUntilWeeklyReset
 local CMI_GetModifiedInstanceInfoFromMapID = C_ModifiedInstance.GetModifiedInstanceInfoFromMapID
@@ -59,12 +58,6 @@ local SECTION_TO_CATEGORIES = {
     },
 }
 
-local REGION_OFFSET = {
-    [1] = -(7 * 60 * 60), -- US events use PST (-0700 UTC)
-    --[2] = ??, -- KR
-    [3] = (1 * 60 * 60),  -- EU events use CEDT? (+0100 UTC)
-    --[4] = ??, -- TW
-}
 local STATUS_COLOR = {
     [0] = '|cFFFF2222',
     [1] = '|cFFFFFF00',
@@ -203,16 +196,7 @@ function Module:ConfigChanged()
 
     self.activeEvents = self.activeEvents or {}
 
-    -- If we have data about what timezone calendar events are actually in, mangle the
-    -- timezones a little to use the correct offset. FFS, Blizzard.
-    local unixTime = time()
-    local region = GetCurrentRegion()
-    if REGION_OFFSET[region] ~= nil then
-        local offset = self:GetTimeZoneOffset(unixTime)
-        unixTime = unixTime - offset + REGION_OFFSET[region]
-    end
-
-    local now = CDAT_GetCalendarTimeFromEpoch(unixTime * 1000000)
+    local now = CDAT_GetCurrentCalendarTime()
 
     -- Check which events are active if the calendar is set to the correct year/month.
     local calendar = C_Calendar.GetMonthInfo(0)
@@ -333,13 +317,6 @@ function Module:ConfigChanged()
     end
 
     self:Redraw()
-end
-
-function Module:GetTimeZoneOffset(now)
-    local localDate = date('*t', now)
-    localDate.isdst = false
-    local utcDate = date('!*t', now)
-    return difftime(time(localDate), time(utcDate))
 end
 
 function Module:AnyActive(activeEvents, eventIds)


### PR DESCRIPTION
I noticed when playing last night that the Darkmoon Faire events were displaying early while they were still constructing the Faire. Changing it over to this method fixed the time.

Comparing the times, it looks like the calculation that was being done here was an hour later than the server time. Perhaps because of daylight savings? This method `GetCurrentCalendarTime` appeared directly to just give the correct time and popped up the Darkmoon hid the Faire events until they were available. (I'm in EST and the Calendar time in PST) 

It looks like you'd worked on this a few years ago in d6134bc so might be something I'm missing here for why this was needed.

Being off an hour or so seems minor but if it works it eliminates some unnecessary code. I dumped the value of the existing code verses this line to compare.

```
    print("Existing Time")
    DevTools_Dump(now)
    print("GetCurrentCalendarTime()")
    DevTools_Dump(C_DateAndTime.GetCurrentCalendarTime()
```

![image](https://github.com/user-attachments/assets/fef61fc7-443a-4d7d-80bf-8a8901242e1f)